### PR TITLE
Changes //@ notation to //# for sourceURL

### DIFF
--- a/lib/modulebuilder.js
+++ b/lib/modulebuilder.js
@@ -38,14 +38,14 @@ inherits(ModuleBuilder, BuilderBase);
  */
 ModuleBuilder.MODULE_WRAPPER =
   '%source%\n' +
-  '//@ sourceURL=%productionUri%%name%.js';
+  '//# sourceURL=%productionUri%%name%.js';
 
 /**
  * @const {string}
  */
 ModuleBuilder.MODULE_WRAPPER_WITH_SCOPE =
   '(function(%renamePrefixNamespace%){%source%})(%globalScopeName%);\n' +
-  '//@ sourceURL=%productionUri%%name%.js';
+  '//# sourceURL=%productionUri%%name%.js';
 
 /**
  * @const {string}


### PR DESCRIPTION
Old IE fails, when tries to process //@ syntax. Also, Chrome raises warning about deprecation.